### PR TITLE
reqHeaders to headers

### DIFF
--- a/examples/express/express.ts
+++ b/examples/express/express.ts
@@ -41,7 +41,7 @@ const newApp = () => {
     const r = res.locals.validate(req).body();
     {
       // Request header also can be validated
-      res.locals.validate(req).reqHeaders();
+      res.locals.validate(req).headers();
     }
     if (r.success) {
       // res.status(200).json() accepts only the response schema defined in pathMap["/users"]["post"].res["200"]

--- a/examples/express/spec.ts
+++ b/examples/express/spec.ts
@@ -10,7 +10,7 @@ export const pathMap = {
       query: z.object({
         page: z.string(),
       }),
-      res: {
+      resBody: {
         200: z.object({ userNames: z.string().array() }),
         400: z.object({ errorMessage: z.string() }),
       },
@@ -18,7 +18,7 @@ export const pathMap = {
     post: {
       headers: JsonHeader,
       resHeaders: JsonHeader,
-      res: {
+      resBody: {
         200: z.object({ userId: z.string() }),
         400: z.object({ errorMessage: z.string() }),
       },
@@ -30,7 +30,7 @@ export const pathMap = {
   "/users/:userId": {
     get: {
       params: z.object({ userId: z.string() }),
-      res: {
+      resBody: {
         200: z.object({ userName: z.string() }),
         400: z.object({ errorMessage: z.string() }),
       },

--- a/examples/express/spec.ts
+++ b/examples/express/spec.ts
@@ -16,7 +16,7 @@ export const pathMap = {
       },
     },
     post: {
-      reqHeaders: JsonHeader,
+      headers: JsonHeader,
       resHeaders: JsonHeader,
       res: {
         200: z.object({ userId: z.string() }),

--- a/examples/simple/spec.ts
+++ b/examples/simple/spec.ts
@@ -7,7 +7,7 @@ export type PathMap = DefineApiEndpoints<{
         200: { userNames: string[] };
         400: { errorMessage: string };
       };
-      reqHeaders: { "Content-Type": "application/json" };
+      headers: { "Content-Type": "application/json" };
       resHeaders: { "Content-Type": "application/json" };
     };
   };

--- a/examples/simple/spec.ts
+++ b/examples/simple/spec.ts
@@ -3,7 +3,7 @@ import { DefineApiEndpoints, FetchT } from "../../src";
 export type PathMap = DefineApiEndpoints<{
   "/users": {
     get: {
-      res: {
+      resBody: {
         200: { userNames: string[] };
         400: { errorMessage: string };
       };

--- a/src/common/spec.ts
+++ b/src/common/spec.ts
@@ -5,7 +5,7 @@ import { ClientResponse, StatusCode } from "./hono-types";
  * { // ApiEndpoints
  *   "/users": { // ApiEndpoint
  *     get: { // ApiSpec
- *       res: {
+ *       resBody: {
  *         200: { p: string }
  *       }
  *     }
@@ -41,7 +41,7 @@ export interface ApiSpec<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Query extends Record<string, string> = Record<string, any>,
   Body extends object = object,
-  Response extends Partial<Record<StatusCode, object>> = Partial<
+  ResBody extends Partial<Record<StatusCode, object>> = Partial<
     Record<StatusCode, object>
   >,
   RequestHeaders extends Record<string, string> = Record<string, string>,
@@ -50,7 +50,7 @@ export interface ApiSpec<
   query?: Query;
   params?: Params;
   body?: Body;
-  res: Response;
+  resBody: ResBody;
   headers?: RequestHeaders;
   resHeaders?: ResponseHeaders;
 }

--- a/src/common/spec.ts
+++ b/src/common/spec.ts
@@ -51,7 +51,7 @@ export interface ApiSpec<
   params?: Params;
   body?: Body;
   res: Response;
-  reqHeaders?: RequestHeaders;
+  headers?: RequestHeaders;
   resHeaders?: ResponseHeaders;
 }
 
@@ -62,11 +62,8 @@ type JsonHeader = {
 type WithJsonHeader<H extends Record<string, string> | undefined> =
   H extends Record<string, string> ? H & JsonHeader : JsonHeader;
 
-type AsJsonApiSpec<AS extends ApiSpec> = Omit<
-  AS,
-  "reqHeaders" | "resHeaders"
-> & {
-  reqHeaders: WithJsonHeader<AS["reqHeaders"]>;
+type AsJsonApiSpec<AS extends ApiSpec> = Omit<AS, "headers" | "resHeaders"> & {
+  headers: WithJsonHeader<AS["headers"]>;
   resHeaders: WithJsonHeader<AS["resHeaders"]>;
 };
 

--- a/src/express/index.ts
+++ b/src/express/index.ts
@@ -28,7 +28,7 @@ export type Handler<
 > = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   req: Request<ParamsDictionary, any, any, ParsedQs, Locals>,
-  res: ExpressResponse<NonNullable<Spec>["res"], 200, Locals>,
+  res: ExpressResponse<NonNullable<Spec>["resBody"], 200, Locals>,
   next: NextFunction,
 ) => void;
 

--- a/src/express/index.ts
+++ b/src/express/index.ts
@@ -144,14 +144,12 @@ export const newValidator = <E extends ZodApiEndpoints>(endpoints: E) => {
         spec?.query?.safeParse(req.query) as E[Path][M] extends ZodApiSpec
           ? ZodValidator<E[Path][M]["query"]>
           : undefined,
-      reqHeaders: () =>
-        spec?.reqHeaders?.safeParse(
-          req.headers,
-        ) as E[Path][M] extends ZodApiSpec
-          ? ZodValidator<E[Path][M]["reqHeaders"]>
+      headers: () =>
+        spec?.headers?.safeParse(req.headers) as E[Path][M] extends ZodApiSpec
+          ? ZodValidator<E[Path][M]["headers"]>
           : undefined,
       resHeaders: () =>
-        spec?.reqHeaders?.safeParse(
+        spec?.resHeaders?.safeParse(
           req.headers,
         ) as E[Path][M] extends ZodApiSpec
           ? ZodValidator<E[Path][M]["resHeaders"]>

--- a/src/fetch/index.t-test.ts
+++ b/src/fetch/index.t-test.ts
@@ -6,7 +6,7 @@ import JSONT from "../json";
   type Spec = DefineApiEndpoints<{
     "/users": {
       get: {
-        res: {
+        resBody: {
           200: { prop: string };
         };
       };
@@ -14,7 +14,7 @@ import JSONT from "../json";
         body: {
           userName: string;
         };
-        res: {
+        resBody: {
           200: { postProp: string };
           400: { error: string };
         };

--- a/src/fetch/index.t-test.ts
+++ b/src/fetch/index.t-test.ts
@@ -67,7 +67,7 @@ import JSONT from "../json";
     }
 
     {
-      // TODO: reqHeadersを定義している場合でもRequestInitが省略できてしまう
+      // TODO: headersを定義している場合でもRequestInitが省略できてしまう
       await f("/users");
     }
 

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -49,7 +49,7 @@ type FetchT<Origin extends UrlPrefixPattern, E extends ApiEndpoints> = <
   init?: RequestInitT<
     InputMethod,
     ApiP<E, CandidatePaths, M, "body">,
-    ApiP<E, CandidatePaths, M, "reqHeaders">
+    ApiP<E, CandidatePaths, M, "headers">
   >,
   // FIXME: NonNullable
 ) => Promise<MergeApiResponses<NonNullable<E[CandidatePaths][M]>["res"]>>;

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -52,6 +52,6 @@ type FetchT<Origin extends UrlPrefixPattern, E extends ApiEndpoints> = <
     ApiP<E, CandidatePaths, M, "headers">
   >,
   // FIXME: NonNullable
-) => Promise<MergeApiResponses<NonNullable<E[CandidatePaths][M]>["res"]>>;
+) => Promise<MergeApiResponses<NonNullable<E[CandidatePaths][M]>["resBody"]>>;
 
 export default FetchT;

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -17,7 +17,7 @@ export type ZodValidators<
       : () => SafeParse<z.ZodType<Record<QueryKeys, string>>>;
   query: ZodValidator<AS["query"]>;
   body: ZodValidator<AS["body"]>;
-  reqHeaders: ZodValidator<AS["reqHeaders"]>;
+  headers: ZodValidator<AS["headers"]>;
   resHeaders: ZodValidator<AS["resHeaders"]>;
 }>;
 type ZodTypeWithKey<Key extends string> = z.ZodType<
@@ -52,7 +52,7 @@ export interface ZodApiSpec<
   params?: Params;
   body?: Body;
   res: Response;
-  reqHeaders?: RequestHeaders;
+  headers?: RequestHeaders;
   resHeaders?: ResponseHeaders;
 }
 export type ZodApiResponses = Partial<Record<StatusCode, z.ZodTypeAny>>;
@@ -75,7 +75,7 @@ export type ToApiSpec<ZAS extends ZodApiSpec> = {
   params: InferOrUndefined<ZAS["params"]>;
   body: InferOrUndefined<ZAS["body"]>;
   res: ToApiResponses<ZAS["res"]>;
-  reqHeaders: InferOrUndefined<ZAS["reqHeaders"]>;
+  headers: InferOrUndefined<ZAS["headers"]>;
   resHeaders: InferOrUndefined<ZAS["resHeaders"]>;
 };
 export type ToApiResponses<AR extends ZodApiResponses> = {

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -44,14 +44,14 @@ export interface ZodApiSpec<
   >,
   Query extends z.ZodTypeAny = z.ZodTypeAny,
   Body extends z.ZodTypeAny = z.ZodTypeAny,
-  Response extends ZodApiResponses = Partial<Record<StatusCode, z.ZodTypeAny>>,
+  ResBody extends ZodApiResponses = Partial<Record<StatusCode, z.ZodTypeAny>>,
   RequestHeaders extends z.ZodTypeAny = z.ZodTypeAny,
   ResponseHeaders extends z.ZodTypeAny = z.ZodTypeAny,
 > {
   query?: Query;
   params?: Params;
   body?: Body;
-  res: Response;
+  resBody: ResBody;
   headers?: RequestHeaders;
   resHeaders?: ResponseHeaders;
 }
@@ -74,7 +74,7 @@ export type ToApiSpec<ZAS extends ZodApiSpec> = {
   query: InferOrUndefined<ZAS["query"]>;
   params: InferOrUndefined<ZAS["params"]>;
   body: InferOrUndefined<ZAS["body"]>;
-  res: ToApiResponses<ZAS["res"]>;
+  resBody: ToApiResponses<ZAS["resBody"]>;
   headers: InferOrUndefined<ZAS["headers"]>;
   resHeaders: InferOrUndefined<ZAS["resHeaders"]>;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated request header field name from `reqHeaders` to `headers` across various files to streamline API specification.
  
- **Bug Fixes**
  - Fixed inconsistencies in request and response header validation logic by standardizing header field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->