### PR TITLE
Allow to omit headers and body if they are all optional

### DIFF
--- a/src/common/type.t-test.ts
+++ b/src/common/type.t-test.ts
@@ -3,6 +3,7 @@ import {
   CountChar,
   ExtractByPrefix,
   FilterNever,
+  IsAllOptional,
   IsEqualNumber,
   Replace,
   ReplaceAll,
@@ -107,4 +108,13 @@ type SameSlashNumTestCases = [
   Expect<Equal<SameSlashNum<string, "/">, false>>,
   Expect<Equal<SameSlashNum<`/${string}`, "/a">, true>>,
   Expect<Equal<SameSlashNum<`/${string}`, "/a/b">, false>>,
+];
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type IsAllOptionalTestCases = [
+  Expect<Equal<IsAllOptional<{}>, true>>,
+  Expect<Equal<IsAllOptional<{ a?: string }>, true>>,
+  Expect<Equal<IsAllOptional<{ a: string }>, false>>,
+  Expect<Equal<IsAllOptional<{ a?: string; b: string }>, false>>,
+  Expect<Equal<IsAllOptional<{ a?: string; b?: string }>, true>>,
 ];

--- a/src/common/type.t-test.ts
+++ b/src/common/type.t-test.ts
@@ -112,6 +112,7 @@ type SameSlashNumTestCases = [
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type IsAllOptionalTestCases = [
+  // eslint-disable-next-line @typescript-eslint/ban-types
   Expect<Equal<IsAllOptional<{}>, true>>,
   Expect<Equal<IsAllOptional<{ a?: string }>, true>>,
   Expect<Equal<IsAllOptional<{ a: string }>, false>>,

--- a/src/common/type.ts
+++ b/src/common/type.ts
@@ -142,3 +142,6 @@ export type SameSlashNum<P1 extends string, P2 extends string> = IsEqualNumber<
   CountChar<P1, "/">,
   CountChar<P2, "/">
 >;
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type IsAllOptional<T> = {} extends T ? true : false;

--- a/src/fetch/index.t-test.ts
+++ b/src/fetch/index.t-test.ts
@@ -145,6 +145,23 @@ const JSONT = JSON as JSONT;
 
 {
   type Spec = DefineApiEndpoints<{
+    "/users": {
+      post: {
+        headers: { "Content-Type"?: "application/json" };
+        body: { userName?: string };
+        responses: { 200: { body: { prop: string } } };
+      };
+    };
+  }>;
+  (async () => {
+    const f = fetch as FetchT<"", Spec>;
+    // headers and body can be omitted because they are optional
+    await f(`/users`, {});
+  })();
+}
+
+{
+  type Spec = DefineApiEndpoints<{
     "/packages/list": {
       get: {
         headers: { Cookie: `a=${string}` };

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -13,6 +13,7 @@ import {
   PathToUrlParamPattern,
   Replace,
   StatusCode,
+  IsAllOptional,
 } from "../common";
 import { UrlPrefixPattern, ToUrlParamPattern } from "../common";
 import { TypedString } from "../json";
@@ -26,9 +27,15 @@ export type RequestInitT<
   method?: InputMethod;
 } & FilterNever<{
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    body: Body extends Record<string, any> ? TypedString<Body> : never;
+    body: Body extends Record<string, any>
+      ? IsAllOptional<Body> extends true
+        ? Body | TypedString<Body> | undefined
+        : TypedString<Body>
+      : never;
     headers: HeadersObj extends Record<string, string>
-      ? HeadersObj | Headers
+      ? IsAllOptional<HeadersObj> extends true
+        ? HeadersObj | Headers | undefined
+        : HeadersObj | Headers
       : never;
   }>;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new type utility, `IsAllOptional`, to evaluate if all properties of an object type are optional.
	- Added specifications for a new API endpoint for user creation, enhancing the API's functionality.
  
- **Bug Fixes**
	- Improved flexibility in handling optional properties for request body and headers in API requests.

- **Documentation**
	- Updated type definitions and specifications for better clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->