### PR TITLE
Accepts string to body

### DIFF
--- a/src/common/spec.ts
+++ b/src/common/spec.ts
@@ -39,10 +39,8 @@ export type AnyApiEndpoints = { [Path in string]: AnyApiEndpoint };
 
 export interface BaseApiSpec<
   Params,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Query,
   Body,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   RequestHeaders,
   Responses extends AnyApiResponses,
 > {
@@ -60,7 +58,8 @@ export type ApiSpec<
   >,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Query extends Record<string, string> = Record<string, any>,
-  Body extends object = object,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Body extends Record<string, any> | string = Record<string, any> | string,
   RequestHeaders extends Record<string, string> = Record<string, string>,
   Responses extends AnyApiResponses = AnyApiResponses,
 > = BaseApiSpec<Params, Query, Body, RequestHeaders, Responses>;

--- a/src/common/spec.ts
+++ b/src/common/spec.ts
@@ -89,7 +89,7 @@ export type ApiP<
 > = E[Path] extends ApiEndpoint
   ? E[Path][M] extends ApiSpec<ParseUrlParams<Path>>
     ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      E[Path][M][P] extends Record<string, any>
+      E[Path][M][P] extends Record<string, any> | string
       ? E[Path][M][P]
       : undefined
     : undefined

--- a/src/fetch/index.t-test.ts
+++ b/src/fetch/index.t-test.ts
@@ -184,7 +184,7 @@ const JSONT = JSON as JSONT;
   }>;
   (async () => {
     const f = fetch as FetchT<"", Spec>;
-    await f(`/users`, { method: "post" });
+    await f(`/users`, { method: "post", body: "some string" });
   })();
 }
 

--- a/src/fetch/index.t-test.ts
+++ b/src/fetch/index.t-test.ts
@@ -175,6 +175,21 @@ const JSONT = JSON as JSONT;
 
 {
   type Spec = DefineApiEndpoints<{
+    "/users": {
+      post: {
+        body: string;
+        responses: { 200: { body: string } };
+      };
+    };
+  }>;
+  (async () => {
+    const f = fetch as FetchT<"", Spec>;
+    await f(`/users`, { method: "post" });
+  })();
+}
+
+{
+  type Spec = DefineApiEndpoints<{
     "/packages/list": {
       get: {
         headers: { Cookie: `a=${string}` };

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -20,7 +20,7 @@ import { TypedString } from "../json";
 export type RequestInitT<
   InputMethod extends CaseInsensitiveMethod,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Body extends Record<string, any> | undefined,
+  Body extends Record<string, any> | string | undefined,
   HeadersObj extends string | Record<string, string> | undefined,
 > = Omit<RequestInit, "method" | "body" | "headers"> &
   (InputMethod extends "get" | "GET"

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -21,7 +21,7 @@ export type RequestInitT<
   InputMethod extends CaseInsensitiveMethod,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Body extends Record<string, any> | undefined,
-  HeadersObj extends Record<string, string> | undefined,
+  HeadersObj extends string | Record<string, string> | undefined,
 > = Omit<RequestInit, "method" | "body" | "headers"> &
   (InputMethod extends "get" | "GET"
     ? { method?: InputMethod }
@@ -31,8 +31,10 @@ export type RequestInitT<
     ? IsAllOptional<Body> extends true
       ? { body?: Body | TypedString<Body> }
       : { body: TypedString<Body> }
-    : // eslint-disable-next-line @typescript-eslint/ban-types
-      {}) &
+    : Body extends string
+      ? { body: string }
+      : // eslint-disable-next-line @typescript-eslint/ban-types
+        {}) &
   (HeadersObj extends Record<string, string>
     ? IsAllOptional<HeadersObj> extends true
       ? { headers?: HeadersObj | Headers }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded the acceptable types for API request bodies, now allowing both string and record formats.
	- Introduced a new type definition for API endpoints, specifically for the `"/users"` POST method.

- **Bug Fixes**
	- Improved type handling for request headers and body properties, ensuring more precise type definitions.

- **Documentation**
	- Removed outdated comments regarding ESLint rules for explicit `any` types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->