### PR TITLE
TypeScript6対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24747,6 +24747,7 @@
         "supertest": "^7.0.0",
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
+        "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.0",
         "vitest": "^2.0.0"
       },
@@ -24790,6 +24791,19 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "pkgs/typed-api-spec/node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     }
   }

--- a/pkgs/typed-api-spec/package.json
+++ b/pkgs/typed-api-spec/package.json
@@ -35,6 +35,7 @@
     "supertest": "^7.0.0",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.0",
     "vitest": "^2.0.0"
   },
@@ -46,7 +47,7 @@
     "fastify": "^4 || ^5.0.0",
     "fastify-type-provider-zod": "^5",
     "msw": "^2",
-    "typescript": "^5.3",
+    "typescript": "^5.3 || ^6",
     "valibot": "^1.0.0",
     "zod": "^4.3.6"
   },

--- a/pkgs/typed-api-spec/src/fetch/index.ts
+++ b/pkgs/typed-api-spec/src/fetch/index.ts
@@ -35,7 +35,9 @@ export type ValidateUrl<
     Record<string, unknown>,
   ]
     ? [QueryKeys] extends [never]
-      ? true
+      ? IsAllOptional<QueryDef & Record<string, unknown>> extends true
+        ? false
+        : true
       : false
     : false,
 > = [QueryRequiredError] extends [true]
@@ -73,6 +75,164 @@ export type RequestInitT<
     : // eslint-disable-next-line @typescript-eslint/no-empty-object-type
       {});
 
+// -- Helper types for FetchT --
+
+/**
+ * Acceptable URL pattern
+ * For example, if endpoints are defined as below:
+ * { "/users": ..., "/users/:userId": ... }
+ * and UrlPrefix is "https://example.com",
+ * then FetchUrlPattern will be "https://example.com/users" | "https://example.com/users/${string}"
+ */
+type FetchUrlPattern<
+  UrlPrefix extends UrlPrefixPattern,
+  E extends ApiEndpoints,
+> = ToUrlParamPattern<`${UrlPrefix}${keyof E & string}`>;
+
+/**
+ * Converted path from `Input`
+ * For example, if Input is "https://example.com/users/1", then FetchInputPath will be "/users/${string}"
+ */
+type FetchInputPath<
+  Input extends string,
+  UrlPrefix extends UrlPrefixPattern,
+> = PathToUrlParamPattern<
+  NormalizePath<
+    ParseURL<Replace<Input, ToUrlParamPattern<UrlPrefix>, "">>["path"] & string
+  >
+>;
+
+/**
+ * Matched paths from `InputPath` and `keyof E`
+ * For example, if InputPath is "/users/1" and endpoints are defined as below:
+ * { "/users": ..., "/users/:userId": ... }
+ * then FetchCandidatePaths will be "/users/:userId"
+ * If no matched path is found, FetchCandidatePaths will be never
+ * If multiple matched paths are found, FetchCandidatePaths will be a union of matched paths
+ */
+type FetchCandidatePaths<
+  Input extends string,
+  UrlPrefix extends UrlPrefixPattern,
+  E extends ApiEndpoints,
+> = MatchedPatterns<
+  FetchInputPath<Input, UrlPrefix> & string,
+  keyof E & string
+>;
+
+/**
+ * Acceptable methods for the matched path
+ * For example, if CandidatePaths is "/users/:userId" and endpoints are defined as below:
+ * { "/users": { get: ... }, "/users/:userId": { get: ..., post: ... } }
+ * then FetchAcceptableMethods will be "get" | "post"
+ */
+type FetchAcceptableMethods<
+  Input extends string,
+  UrlPrefix extends UrlPrefixPattern,
+  E extends ApiEndpoints,
+> =
+  FetchCandidatePaths<Input, UrlPrefix, E> extends string
+    ? Extract<Method, keyof E[FetchCandidatePaths<Input, UrlPrefix, E>]>
+    : never;
+
+/** Extract a specific property (query, headers, body, responses) from the matched endpoint. */
+type FetchApiProp<
+  Input extends string,
+  UrlPrefix extends UrlPrefixPattern,
+  E extends ApiEndpoints,
+  InputMethod extends string,
+  P extends "query" | "headers" | "body" | "responses",
+> = ApiP<
+  E,
+  FetchCandidatePaths<Input, UrlPrefix, E>,
+  Lowercase<InputMethod>,
+  P
+>;
+
+/** Response object of the endpoint that matches `CandidatePaths` */
+type FetchResponse<
+  Input extends string,
+  UrlPrefix extends UrlPrefixPattern,
+  E extends ApiEndpoints,
+  InputMethod extends string,
+> =
+  FetchApiProp<
+    Input,
+    UrlPrefix,
+    E,
+    InputMethod,
+    "responses"
+  > extends AnyApiResponses
+    ? MergeApiResponseBodies<
+        FetchApiProp<Input, UrlPrefix, E, InputMethod, "responses">
+      >
+    : Record<StatusCode, never>;
+
+/**
+ * Whether the method property in the "init" parameter can be omitted
+ * If the endpoint defines a "get" method, then the method can be omitted
+ */
+type FetchCanOmitMethod<
+  Input extends string,
+  UrlPrefix extends UrlPrefixPattern,
+  E extends ApiEndpoints,
+> = "get" extends FetchAcceptableMethods<Input, UrlPrefix, E> ? true : false;
+
+/** Whether the headers property in the "init" parameter can be omitted */
+type FetchCanOmitHeaders<
+  Input extends string,
+  UrlPrefix extends UrlPrefixPattern,
+  E extends ApiEndpoints,
+  InputMethod extends string,
+  Headers = FetchApiProp<Input, UrlPrefix, E, InputMethod, "headers">,
+> = Headers extends undefined
+  ? true
+  : IsAllOptional<Headers & Record<string, unknown>>;
+
+/** Whether the body property in the "init" parameter can be omitted */
+type FetchCanOmitBody<
+  Input extends string,
+  UrlPrefix extends UrlPrefixPattern,
+  E extends ApiEndpoints,
+  InputMethod extends string,
+  Body = FetchApiProp<Input, UrlPrefix, E, InputMethod, "body">,
+> = Body extends undefined
+  ? true
+  : IsAllOptional<Body & Record<string, unknown>>;
+
+/**
+ * Whether the "init" parameter can be omitted for the request
+ * If the method can be omitted (`CanOmitMethod` is true), headers can be omitted (`CanOmitHeaders` is true), and body can be omitted (`CanOmitBody` is true), then the "init" parameter can be omitted
+ */
+type FetchCanOmitInit<
+  Input extends string,
+  UrlPrefix extends UrlPrefixPattern,
+  E extends ApiEndpoints,
+  InputMethod extends string,
+> = And<
+  [
+    FetchCanOmitMethod<Input, UrlPrefix, E>,
+    FetchCanOmitHeaders<Input, UrlPrefix, E, InputMethod>,
+    FetchCanOmitBody<Input, UrlPrefix, E, InputMethod>,
+  ]
+>;
+
+/** Result of URL validation */
+type FetchValidatedUrl<
+  Input extends string,
+  UrlPrefix extends UrlPrefixPattern,
+  E extends ApiEndpoints,
+  InputMethod extends string,
+> = ValidateUrl<FetchApiProp<Input, UrlPrefix, E, InputMethod, "query">, Input>;
+
+/** Compute the input parameter type: Input if valid, otherwise the validation error. */
+type FetchInputType<
+  Input extends string,
+  UrlPrefix extends UrlPrefixPattern,
+  E extends ApiEndpoints,
+  InputMethod extends string,
+  Validated = FetchValidatedUrl<Input, UrlPrefix, E, InputMethod>,
+> = [Validated] extends [C.OK] ? Input : Validated;
+
 /**
  * FetchT is a type for window.fetch like function but more strict type information
  *
@@ -87,107 +247,53 @@ type FetchT<UrlPrefix extends UrlPrefixPattern, E extends ApiEndpoints> = <
    * Internal type for FetchT
    * They are not supposed to be specified by the user
    *
-   * @template UrlPattern - Acceptable URL pattern
-   * For example, if endpoints are defined as below:
-   * { "/users": ..., "/users/:userId": ... }
-   * and UrlPrefix is "https://example.com",
-   * then UrlPattern will be "https://example.com/users" | "https://example.com/users/${string}"
-   *
    * @template Input - Input of the request by the user
    * For example, if endpoints are defined as below:
    * { "/users": ..., "/users/:userId": ... }
    * then Input accepts "https://example.com/users" | "https://example.com/users/${string}"
    * If query is defined in the spec, Input also accepts "https://example.com/users?${string}" | "https://example.com/users/${string}?${string}"
    *
-   * @template InputPath - Converted path from `Input`
-   * For example, if Input is "https://example.com/users/1", then InputPath will be "/users/${string}"
-   *
-   * @template CandidatePaths - Matched paths from `InputPath` and `keyof E`
-   * For example, if InputPath is "/users/1" and endpoints are defined as below:
-   * { "/users": ..., "/users/:userId": ... }
-   * then CandidatePaths will be "/users/:userId"
-   * If no matched path is found, CandidatePaths will be never
-   * If multiple matched paths are found, CandidatePaths will be a union of matched paths
-   *
-   * @template AcceptableMethods - Acceptable methods for the matched path
-   * For example, if CandidatePaths is "/users/:userId" and endpoints are defined as below:
-   * { "/users": { get: ... }, "/users/:userId": { get: ..., post: ... } }
-   * then AcceptableMethods will be "get" | "post"
-   *
-   * @template LM - Lowercase version of `InputMethod`
-   *
-   * @template Query - Query object of the endpoint that matches `CandidatePaths`
-   *
-   * @template Headers - Request headers object of the endpoint
-   *
-   * @template CanOmitHeaders - Whether the headers property in the "init" parameter can be omitted
-   *
-   * @template Body - Request body object of the endpoint
-   *
-   * @template CanOmitBody - Whether the body property in the "init" parameter can be omitted
-   *
-   * @template Response - Response object of the endpoint that matches `CandidatePaths`
-   *
-   * @template ValidatedUrl - Result of URL validation
-   *
    * @template InputMethod - Method of the request as specified by the user
    * For example, if `fetch` is called with `fetch("https://example.com/users", { method: "post" })`,
    * then InputMethod will be "post".
    * If `get` method is defined in the spec, method can be omitted, and it will be `get` by default
    *
-   * @template CanOmitMethod - Whether the method property in the "init" parameter can be omitted
-   * If the endpoint defines a "get" method, then the method can be omitted
+   * @template Response - Response object of the endpoint that matches `CandidatePaths`
    *
-   * @template CanOmitInit - Whether the "init" parameter can be omitted for the request
-   * If the method can be omitted (`CanOmitMethod` is true), headers can be omitted (`CanOmitHeaders` is true), and body can be omitted (`CanOmitBody` is true), then the "init" parameter can be omitted
+   * Other types (InputPath, CandidatePaths, AcceptableMethods, Query, Headers,
+   * Body, etc.) are computed via helper types (Fetch*) rather than type parameters,
+   * to avoid circular type parameter constraints in TypeScript 6+.
    */
-  UrlPattern extends ToUrlParamPattern<`${UrlPrefix}${keyof E & string}`>,
-  Input extends Query extends undefined
-    ? UrlPattern
-    : IsAllOptional<Query> extends true
-      ? UrlPattern | `${UrlPattern}?${string}`
-      : `${UrlPattern}?${string}`,
-  InputPath extends PathToUrlParamPattern<
-    NormalizePath<
-      ParseURL<Replace<Input, ToUrlParamPattern<UrlPrefix>, "">>["path"]
-    >
-  >,
-  CandidatePaths extends MatchedPatterns<InputPath, keyof E & string>,
-  AcceptableMethods extends CandidatePaths extends string
-    ? Extract<Method, keyof E[CandidatePaths]>
-    : never,
-  LM extends Lowercase<InputMethod>,
-  Query extends ApiP<E, CandidatePaths, LM, "query">,
-  Headers extends ApiP<E, CandidatePaths, LM, "headers">,
-  CanOmitHeaders extends Headers extends undefined
-    ? true
-    : IsAllOptional<Headers>,
-  Body extends ApiP<E, CandidatePaths, LM, "body">,
-  CanOmitBody extends Body extends undefined ? true : IsAllOptional<Body>,
-  Response extends ApiP<
-    E,
-    CandidatePaths,
-    LM,
-    "responses"
-  > extends AnyApiResponses
-    ? MergeApiResponseBodies<ApiP<E, CandidatePaths, LM, "responses">>
-    : Record<StatusCode, never>,
-  ValidatedUrl extends ValidateUrl<Query, Input>,
-  CanOmitMethod extends "get" extends AcceptableMethods ? true : false,
-  InputMethod extends CaseInsensitive<AcceptableMethods> = Extract<
-    AcceptableMethods,
-    "get"
-  >,
-  CanOmitInit extends boolean = And<
-    [CanOmitMethod, CanOmitHeaders, CanOmitBody]
-  >,
+  Input extends
+    | FetchUrlPattern<UrlPrefix, E>
+    | `${FetchUrlPattern<UrlPrefix, E>}?${string}`,
+  InputMethod extends CaseInsensitive<
+    FetchAcceptableMethods<Input, UrlPrefix, E>
+  > = Extract<FetchAcceptableMethods<Input, UrlPrefix, E>, "get">,
+  Response = FetchResponse<Input, UrlPrefix, E, InputMethod>,
 >(
-  input: [ValidatedUrl] extends [C.OK | QueryParameterRequiredError]
-    ? Input
-    : ValidatedUrl,
-  ...args: CanOmitInit extends true
-    ? [init?: RequestInitT<CanOmitMethod, Body, Headers, InputMethod>]
-    : [init: RequestInitT<CanOmitMethod, Body, Headers, InputMethod>]
+  input: FetchInputType<Input, UrlPrefix, E, InputMethod>,
+  ...args: FetchCanOmitInit<Input, UrlPrefix, E, InputMethod> extends true
+    ? [
+        init?: RequestInitT<
+          FetchCanOmitMethod<Input, UrlPrefix, E>,
+          FetchApiProp<Input, UrlPrefix, E, InputMethod, "body"> &
+            (Record<string, unknown> | string | undefined),
+          FetchApiProp<Input, UrlPrefix, E, InputMethod, "headers"> &
+            (string | Record<string, string> | undefined),
+          InputMethod & CaseInsensitiveMethod
+        >,
+      ]
+    : [
+        init: RequestInitT<
+          FetchCanOmitMethod<Input, UrlPrefix, E>,
+          FetchApiProp<Input, UrlPrefix, E, InputMethod, "body"> &
+            (Record<string, unknown> | string | undefined),
+          FetchApiProp<Input, UrlPrefix, E, InputMethod, "headers"> &
+            (string | Record<string, string> | undefined),
+          InputMethod & CaseInsensitiveMethod
+        >,
+      ]
 ) => Promise<Response>;
 
 export default FetchT;

--- a/pkgs/typed-api-spec/src/fetch/validation.ts
+++ b/pkgs/typed-api-spec/src/fetch/validation.ts
@@ -141,11 +141,17 @@ export const withValidation = <
 };
 
 export class SpecValidatorError extends Error {
+  reason: keyof AnySpecValidator | "preCheck";
+  error: Readonly<StandardSchemaV1.Issue[]>;
+  override message: string;
   constructor(
-    public reason: keyof AnySpecValidator | "preCheck",
-    public error: Readonly<StandardSchemaV1.Issue[]>,
-    public message: string = JSON.stringify({ reason, ...error }),
+    reason: keyof AnySpecValidator | "preCheck",
+    error: Readonly<StandardSchemaV1.Issue[]>,
+    message: string = JSON.stringify({ reason, ...error }),
   ) {
     super("Validation error");
+    this.reason = reason;
+    this.error = error;
+    this.message = message;
   }
 }

--- a/pkgs/typed-api-spec/tsconfig.json
+++ b/pkgs/typed-api-spec/tsconfig.json
@@ -107,6 +107,7 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
+    "erasableSyntaxOnly": true
   }
 }


### PR DESCRIPTION
## Summary

- TypeScript 6 サポートを追加
- `peerDependencies` を `^5.3 || ^6` に更新、`devDependencies` に `typescript@^6` を追加
- `FetchT` の循環型パラメータ制約を解消（TS6で検出されるようになった `Input → Query → CandidatePaths → InputPath → Input` の循環を、ヘルパー型への切り出しで解決）
- `ValidateUrl` にクエリパラメータが全てオプショナルな場合のチェックを追加
- `erasableSyntaxOnly` を有効化し、`SpecValidatorError` のコンストラクタパラメータプロパティを通常のプロパティ宣言に変更

## Test plan

- [x] `npm run test -w pkgs/typed-api-spec` が全て通ることを確認
- [x] 型テスト (`index.t-test.ts`) の既存テストが全て通ることを確認
- [x] CI が通ることを確認