### PR TITLE
chore: bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24722,7 +24722,7 @@
     },
     "pkgs/typed-api-spec": {
       "name": "@notainc/typed-api-spec",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.3",
@@ -24762,7 +24762,7 @@
         "fastify": "^4 || ^5.0.0",
         "fastify-type-provider-zod": "^5",
         "msw": "^2",
-        "typescript": "^5.3",
+        "typescript": "^5.3 || ^6",
         "valibot": "^1.0.0",
         "zod": "^4.3.6"
       },

--- a/pkgs/typed-api-spec/package.json
+++ b/pkgs/typed-api-spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notainc/typed-api-spec",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "scripts": {
     "install:optional-peer-dependencies": "npm install --no-save zod valibot@1 express@5 @types/express@5 fastify fastify-type-provider-zod@5",
     "build": "tsup",


### PR DESCRIPTION
TypeScript更新のため 0.7.x → 0.8.x に更新