### PR TITLE
dependabotのルール設定の導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    versioning-strategy: increase
+    labels:
+      - 'dependencies'
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,41 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge "$PR_NUMBER" --squash --auto
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Update branch if behind main
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          STATUS=$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus')
+          if [ "$STATUS" = "BEHIND" ]; then
+             echo "Branch is behind main, requesting rebase..."
+             gh pr comment "$PR_NUMBER" --body "@dependabot rebase"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           STATUS=$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus')
           if [ "$STATUS" = "BEHIND" ]; then
-             echo "Branch is behind main, requesting rebase..."
-             gh pr comment "$PR_NUMBER" --body "@dependabot rebase"
+            echo "Branch is behind main, updating..."
+            gh pr update-branch "$PR_NUMBER"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           STATUS=$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus')
           if [ "$STATUS" = "BEHIND" ]; then
-            echo "Branch is behind main, updating..."
-            gh pr update-branch "$PR_NUMBER"
+            echo "Branch is behind main, requesting rebase..."
+             gh pr comment "$PR_NUMBER" --body "@dependabot rebase"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pkgs/typed-api-spec/renovate.json
+++ b/pkgs/typed-api-spec/renovate.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "automerge": true
-}


### PR DESCRIPTION
## Description

dependabot の PR の自動マージを有効化する。
あわせて、二重管理になっていた Renovate の設定を削除して Dependabot に一本化する。

## Summary

- `.github/dependabot.yml` を新規追加
- `.github/workflows/dependabot-auto-merge.yml` を新規追加
- `pkgs/typed-api-spec/renovate.json` を削除

## Notes

- npm は workspaces 構成（`pkgs/*`, `examples/*`）だが、root の `directory: '/'` 指定で workspace 配下の dep も検知される
- 既存の Renovate PR (#115, #74, #8) は別途手動で close する
- このマージ後、Repo Settings → General → Pull Requests の "Allow auto-merge" を ON にする必要あり