### PR TITLE
fix: Dependabot auto-merge後にmainのCIが走らない問題を修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
     versioning-strategy: increase
     labels:
       - 'dependencies'
@@ -14,6 +14,6 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
     labels:
       - 'dependencies'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,29 +13,23 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Enable auto-merge for non-major updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge "$PR_NUMBER" --squash --auto
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      - name: Update branch if behind main
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: |
-          STATUS=$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus')
-          if [ "$STATUS" = "BEHIND" ]; then
-            echo "Branch is behind main, requesting rebase..."
-             gh pr comment "$PR_NUMBER" --body "@dependabot rebase"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,6 +26,14 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
 
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "$PR_NUMBER"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
       - name: Enable auto-merge for non-major updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge "$PR_NUMBER" --squash --auto


### PR DESCRIPTION
## 概要 | About


- dependabot-auto-merge.yml: GITHUB_TOKEN の代わりに GitHub App トークンを使用するよう変更
- Update branchのステップを削除(dependabotが自動でrebaseする想定)
- dependabot.yml: スケジュールを weekly から daily に変更

## 背景

GITHUB_TOKEN を使った auto-merge では、main へのマージ後に push イベントが発火せず、main の CI が走らない問題があった。GitHub App のインストールトークンはこの制限がないため、マージ後に正しく CI がトリガーされる。


## 手動作業（マージ前に確認）

- GitHub App の Client ID を APP_CLIENT_ID としてリポジトリ変数（vars）に登録
- GitHub App の秘密鍵を APP_PRIVATE_KEY としてリポジトリ secrets に登録