### PR TITLE
chore: group react-related dependencies in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
       docusaurus:
         patterns:
           - '@docusaurus/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## 概要
Dependabot の npm 設定に `react` グループを追加し、以下 4 パッケージを 1 つの PR にまとめる。

- `react`
- `react-dom`
- `@types/react`
- `@types/react-dom`

## 背景
現状これらは個別 PR で上がってくる（例: #193 react, #197 react-dom）。React 19 系にメジャーが変わったとき、`react` と `react-dom` のメジャーが揃わない中間状態が生まれ、`TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')` で docs (docusaurus) の build が壊れる。

同じメジャーで揃えて上げるのが前提なので、Dependabot 側で group 化して 1 PR に集約する。

## スコープ外
- 既存 PR #193 / #197 の扱い（この設定変更が merge されて Dependabot が再スキャンした後に、まとめた新規 PR が上がる想定。旧 PR は必要に応じて手動で close）
- React 18 → 19 への実際の移行作業
