### PR TITLE
Viteのローカルデモ修正

### DIFF
--- a/examples/misc/express/zod/openapi/index.ts
+++ b/examples/misc/express/zod/openapi/index.ts
@@ -1,7 +1,6 @@
 import express from "express";
 import cors from "cors";
 import { OpenAPIV3_1 } from "openapi-types";
-import "zod-openapi/extend";
 import z from "zod";
 import {
   OpenApiEndpointsSchema,

--- a/examples/vite-react-openapi/README.md
+++ b/examples/vite-react-openapi/README.md
@@ -1,50 +1,41 @@
-# React + TypeScript + Vite
+# typed-api-spec + Swagger UI (React + Vite)
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+typed-api-spec で書いた API 定義から自動生成した OpenAPI ドキュメントを、ブラウザで Swagger UI として表示するデモ。
 
-Currently, two official plugins are available:
+## デモの内容
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+このアプリ自体は 10 行程度の React で、`swagger-ui-react` に `http://localhost:3000/openapi` を渡してるだけ。
+「同エンドポイントに OpenAPI JSON を配信するサーバー」と **ペアで動かす** 前提の構成。
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```
+[examples/misc の Express server]              [このアプリ]
+localhost:3000/openapi ─── OpenAPI JSON ──▶ localhost:5173 (Swagger UI)
 ```
 
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
+## 起動方法
 
-```js
-// eslint.config.js
-import react from 'eslint-plugin-react'
+2 プロセス必要。repo のルートから:
 
-export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '18.3' } },
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
+**1. サーバー側**（OpenAPI 配信の Express アプリを起動）
+```bash
+npm run ex:express:zod:openapi -w examples/misc
+# → localhost:3000 で立つ
 ```
+
+**2. Swagger UI 側**
+```bash
+# typed-api-spec 本体をビルド
+npm run build -w pkgs/typed-api-spec
+
+# dev server 起動
+npm run dev -w examples/vite-react-openapi
+# → localhost:5173 で立つ
+```
+
+ブラウザで `http://localhost:5173/` を開くと、typed-api-spec 生成の OpenAPI 仕様に基づく Swagger UI が表示される。
+
+## 見どころ
+
+- サーバー側（[examples/misc/express/zod/openapi/index.ts](../misc/express/zod/openapi/index.ts)）は typed-api-spec の spec を書いて `toOpenApiDoc` で OpenAPI JSON に変換 → `/openapi` で serve するだけ
+- 「型定義から OpenAPI ドキュメントを一次情報として自動生成できる」ことが売り
+- Valibot 版に切り替える場合は `npm run ex:express:valibot:openapi -w examples/misc` に差し替え

--- a/examples/vite-react-openapi/README.md
+++ b/examples/vite-react-openapi/README.md
@@ -1,41 +1,20 @@
 # typed-api-spec + Swagger UI (React + Vite)
 
-typed-api-spec で書いた API 定義から自動生成した OpenAPI ドキュメントを、ブラウザで Swagger UI として表示するデモ。
-
-## デモの内容
-
-このアプリ自体は 10 行程度の React で、`swagger-ui-react` に `http://localhost:3000/openapi` を渡してるだけ。
-「同エンドポイントに OpenAPI JSON を配信するサーバー」と **ペアで動かす** 前提の構成。
-
-```
-[examples/misc の Express server]              [このアプリ]
-localhost:3000/openapi ─── OpenAPI JSON ──▶ localhost:5173 (Swagger UI)
-```
+`swagger-ui-react` で `http://localhost:3000/openapi` を表示する。同エンドポイントを配信するサーバー ([examples/misc/express/zod/openapi/index.ts](../misc/express/zod/openapi/index.ts)) と組で動く。
 
 ## 起動方法
 
-2 プロセス必要。repo のルートから:
+repo のルートから 2 プロセス起動。
 
-**1. サーバー側**（OpenAPI 配信の Express アプリを起動）
+サーバー側:
 ```bash
 npm run ex:express:zod:openapi -w examples/misc
-# → localhost:3000 で立つ
+# localhost:3000
 ```
 
-**2. Swagger UI 側**
+Swagger UI 側:
 ```bash
-# typed-api-spec 本体をビルド
 npm run build -w pkgs/typed-api-spec
-
-# dev server 起動
 npm run dev -w examples/vite-react-openapi
-# → localhost:5173 で立つ
+# localhost:5173
 ```
-
-ブラウザで `http://localhost:5173/` を開くと、typed-api-spec 生成の OpenAPI 仕様に基づく Swagger UI が表示される。
-
-## 見どころ
-
-- サーバー側（[examples/misc/express/zod/openapi/index.ts](../misc/express/zod/openapi/index.ts)）は typed-api-spec の spec を書いて `toOpenApiDoc` で OpenAPI JSON に変換 → `/openapi` で serve するだけ
-- 「型定義から OpenAPI ドキュメントを一次情報として自動生成できる」ことが売り
-- Valibot 版に切り替える場合は `npm run ex:express:valibot:openapi -w examples/misc` に差し替え

--- a/examples/vite-react-openapi/package.json
+++ b/examples/vite-react-openapi/package.json
@@ -25,6 +25,6 @@
     "globals": "^17.6.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.61.1",
-    "vite": "^6.0.5"
+    "vite": "^8.0.16"
   }
 }

--- a/examples/vite/readme.md
+++ b/examples/vite/readme.md
@@ -1,0 +1,29 @@
+# typed-api-spec + Vite (vanilla TS)
+
+Vite でバンドルしたブラウザから typed-api-spec を使う最小サンプル。React 版は [`examples/vite-react-openapi`](../vite-react-openapi) を参照。
+
+## デモの内容
+
+GitHub 公式 API `GET /repos/{owner}/{repo}/topics` を叩き、typed-api-spec の **実行時 spec 検証**（`withValidation`）を dev 時のみ有効化する挙動を見せる。
+
+- **Fetch from GitHub**: spec が実際のレスポンスと一致 → 正常に topics を表示
+- **Invalid fetch from GitHub**: わざと壊した spec (`{ noexistProps: string[] }`) で validation → `SpecValidatorError` を throw
+
+## 起動方法
+
+repo のルートから:
+
+```bash
+# typed-api-spec 本体をビルド（examples が dist を参照するため）
+npm run build -w pkgs/typed-api-spec
+
+# dev server 起動（デフォルト http://localhost:5173）
+npm run dev -w examples/vite
+```
+
+typed-api-spec 側のコードを弄ったら再度 `npm run build -w pkgs/typed-api-spec` するか、`npm run watch:build -w pkgs/typed-api-spec` を別ターミナルで常駐させる。
+
+## 見どころ
+
+- [src/main.ts](src/main.ts): `withValidation` の on/off を `import.meta.env.DEV` で切り替え。production build では validation コードごと dead-code elimination される
+- [src/github/spec.ts](src/github/spec.ts): `ApiEndpointsSchema` を satisfies した最小 spec の書き方

--- a/examples/vite/readme.md
+++ b/examples/vite/readme.md
@@ -1,29 +1,13 @@
-# typed-api-spec + Vite (vanilla TS)
+# typed-api-spec + Vite
 
-Vite でバンドルしたブラウザから typed-api-spec を使う最小サンプル。React 版は [`examples/vite-react-openapi`](../vite-react-openapi) を参照。
-
-## デモの内容
-
-GitHub 公式 API `GET /repos/{owner}/{repo}/topics` を叩き、typed-api-spec の **実行時 spec 検証**（`withValidation`）を dev 時のみ有効化する挙動を見せる。
-
-- **Fetch from GitHub**: spec が実際のレスポンスと一致 → 正常に topics を表示
-- **Invalid fetch from GitHub**: わざと壊した spec (`{ noexistProps: string[] }`) で validation → `SpecValidatorError` を throw
+Vite でバンドルしたブラウザから typed-api-spec を使うサンプル。
 
 ## 起動方法
 
 repo のルートから:
 
 ```bash
-# typed-api-spec 本体をビルド（examples が dist を参照するため）
 npm run build -w pkgs/typed-api-spec
-
-# dev server 起動（デフォルト http://localhost:5173）
 npm run dev -w examples/vite
+# http://localhost:5173
 ```
-
-typed-api-spec 側のコードを弄ったら再度 `npm run build -w pkgs/typed-api-spec` するか、`npm run watch:build -w pkgs/typed-api-spec` を別ターミナルで常駐させる。
-
-## 見どころ
-
-- [src/main.ts](src/main.ts): `withValidation` の on/off を `import.meta.env.DEV` で切り替え。production build では validation コードごと dead-code elimination される
-- [src/github/spec.ts](src/github/spec.ts): `ApiEndpointsSchema` を satisfies した最小 spec の書き方

--- a/examples/vite/src/github/spec.ts
+++ b/examples/vite/src/github/spec.ts
@@ -1,5 +1,8 @@
 import z from "zod";
-import { SSApiEndpoints, ToApiEndpoints } from "@notainc/typed-api-spec/ss";
+import {
+  ApiEndpointsSchema,
+  ToApiEndpoints,
+} from "@notainc/typed-api-spec/core";
 
 // See https://docs.github.com/ja/rest/repos/repos?apiVersion=2022-11-28#get-all-repository-topics
 export const GitHubSpec = {
@@ -18,7 +21,7 @@ export const GitHubSpec = {
       },
     },
   },
-} satisfies SSApiEndpoints;
+} satisfies ApiEndpointsSchema;
 export type Spec = ToApiEndpoints<typeof GitHubSpec>;
 
 // See https://docs.github.com/ja/rest/repos/repos?apiVersion=2022-11-28#get-all-repository-topics
@@ -30,7 +33,7 @@ export const InvalidResponseGitHubSpec = {
       },
     },
   },
-} satisfies SSApiEndpoints;
+} satisfies ApiEndpointsSchema;
 export type InvalidResponseSpec = ToApiEndpoints<
   typeof InvalidResponseGitHubSpec
 >;

--- a/examples/vite/src/main.ts
+++ b/examples/vite/src/main.ts
@@ -1,4 +1,9 @@
 import "./style.css";
+import {
+  withValidation,
+  SpecValidatorError,
+} from "@notainc/typed-api-spec/fetch";
+import { GitHubSpec, InvalidResponseGitHubSpec } from "./github/spec.ts";
 
 document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
   <div>
@@ -15,19 +20,20 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
   </div>
 `;
 
-import { newFetch } from "@notainc/typed-api-spec/zod";
 const GITHUB_API_ORIGIN = "https://api.github.com";
-
 const endpoint = `${GITHUB_API_ORIGIN}/repos/nota/typed-api-spec/topics`;
 const result = document.querySelector<HTMLParagraphElement>("#result")!;
 
-const fetchButton = document.querySelector<HTMLButtonElement>("#fetch")!;
-const request = async () => {
-  const specLoader = async () => (await import("./github/spec.ts")).GitHubSpec;
-  const fetchGitHub = await newFetch(specLoader, import.meta.env.DEV)<
-    typeof GITHUB_API_ORIGIN
-  >();
+// Validation cost is dev-only: production uses raw fetch to avoid shipping schemas.
+const fetchGitHub = import.meta.env.DEV
+  ? withValidation(fetch, GitHubSpec)
+  : fetch;
+const fetchInvalidResponseGitHub = import.meta.env.DEV
+  ? withValidation(fetch, InvalidResponseGitHubSpec)
+  : fetch;
 
+const fetchButton = document.querySelector<HTMLButtonElement>("#fetch")!;
+fetchButton.addEventListener("click", async () => {
   result.innerHTML = "Loading...";
   const response = await fetchGitHub(endpoint, {});
   if (!response.ok) {
@@ -36,19 +42,11 @@ const request = async () => {
   }
   const { names } = await response.json();
   result.innerHTML = `Result: ${names.join(", ")}`;
-};
-fetchButton.addEventListener("click", () => request());
+});
 
 const invalidFetchButton =
   document.querySelector<HTMLButtonElement>("#invalid-fetch")!;
-const invalidRequest = async () => {
-  const specLoader = async () =>
-    (await import("./github/spec.ts")).InvalidResponseGitHubSpec;
-  const fetchInvalidResponseGitHub = await newFetch(
-    specLoader,
-    import.meta.env.DEV
-  )<typeof GITHUB_API_ORIGIN>();
-
+invalidFetchButton.addEventListener("click", async () => {
   result.innerHTML = "Loading...";
   try {
     const response = await fetchInvalidResponseGitHub(endpoint, {});
@@ -59,7 +57,10 @@ const invalidRequest = async () => {
     const { noexistProps } = await response.json();
     result.innerHTML = `Result: ${noexistProps.join(", ")}`;
   } catch (e) {
-    result.innerHTML = `${e}`;
+    if (e instanceof SpecValidatorError) {
+      result.innerHTML = `SpecValidatorError: ${e.message}`;
+    } else {
+      result.innerHTML = `${e}`;
+    }
   }
-};
-invalidFetchButton.addEventListener("click", () => invalidRequest());
+});

--- a/examples/vite/src/main.ts
+++ b/examples/vite/src/main.ts
@@ -24,7 +24,6 @@ const GITHUB_API_ORIGIN = "https://api.github.com";
 const endpoint = `${GITHUB_API_ORIGIN}/repos/nota/typed-api-spec/topics`;
 const result = document.querySelector<HTMLParagraphElement>("#result")!;
 
-// Validation cost is dev-only: production uses raw fetch to avoid shipping schemas.
 const fetchGitHub = import.meta.env.DEV
   ? withValidation(fetch, GitHubSpec)
   : fetch;

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "globals": "^17.6.0",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.61.1",
-        "vite": "^6.0.5"
+        "vite": "^8.0.16"
       }
     },
     "examples/vite-react-openapi/node_modules/@eslint/eslintrc": {
@@ -105,6 +105,272 @@
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
+      "integrity": "sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
+      "integrity": "sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.2.tgz",
+      "integrity": "sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.2.tgz",
+      "integrity": "sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
+      "integrity": "sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
+      "integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.2.tgz",
+      "integrity": "sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.2.tgz",
+      "integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
+      "integrity": "sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
+      "integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.2.tgz",
+      "integrity": "sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
+      "integrity": "sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.2.tgz",
+      "integrity": "sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "examples/vite-react-openapi/node_modules/@vitejs/plugin-react": {
@@ -315,22 +581,70 @@
         "node": "*"
       }
     },
-    "examples/vite-react-openapi/node_modules/vite": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.7.tgz",
-      "integrity": "sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==",
+    "examples/vite-react-openapi/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/rolldown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.2.tgz",
+      "integrity": "sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.24.2",
-        "postcss": "^8.4.49",
-        "rollup": "^4.23.0"
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.2",
+        "@rolldown/binding-darwin-arm64": "1.2.2",
+        "@rolldown/binding-darwin-x64": "1.2.2",
+        "@rolldown/binding-freebsd-x64": "1.2.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.2",
+        "@rolldown/binding-linux-arm64-musl": "1.2.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-musl": "1.2.2",
+        "@rolldown/binding-openharmony-arm64": "1.2.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.2",
+        "@rolldown/binding-win32-x64-msvc": "1.2.2"
+      }
+    },
+    "examples/vite-react-openapi/node_modules/vite": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -339,14 +653,15 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -355,13 +670,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -15835,9 +16153,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -15851,23 +16169,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -15886,9 +16204,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -15907,9 +16225,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -15928,9 +16246,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -15949,9 +16267,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -15970,13 +16288,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15991,13 +16312,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16012,13 +16336,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16033,13 +16360,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16054,9 +16384,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -16075,9 +16405,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,8 @@
   * hosted on nota.github.io/typed-api-spec/
 * examples
   * examples of using the typed-api-spec package
+  * [examples/vite](examples/vite) — Vite + vanilla TS でのブラウザ利用例
+  * [examples/misc](examples/misc) — Express / Fastify / fetch 系サンプル
 
 ## Publishing
 

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@
 * examples
   * examples of using the typed-api-spec package
   * [examples/vite](examples/vite) — Vite + vanilla TS でのブラウザ利用例
+  * [examples/vite-react-openapi](examples/vite-react-openapi) — React + Vite + Swagger UI（OpenAPI 自動生成の可視化デモ）
   * [examples/misc](examples/misc) — Express / Fastify / fetch 系サンプル
 
 ## Publishing


### PR DESCRIPTION
## 概要
vite の脆弱性対応（アップグレード） に着手する前段として、`examples/vite` / `examples/vite-react-openapi` のローカルデモが起動できなかったため復旧させた。

- 判明した事象:
  - `examples/vite`: typed-api-spec の API 変更（`newFetch` / `/zod` / `/ss` 削除）に追従できておらず `Missing "./zod" specifier` 
  - `examples/vite-react-openapi`: `@vitejs/plugin-react@6.0.2` の peer (`vite: ^8.0.0`) と install 済 `vite@6.0.7` の齟齬で `./internal` サブパスエラー
  - `examples/misc/express/zod/openapi/index.ts`: zod-openapi 5.x で削除された `./extend` サブパスを import していた


## 変更内容

### examples/vite
- examples/vite/src/main.ts: `newFetch(specLoader, DEV)` → `import.meta.env.DEV ? withValidation(fetch, spec) : fetch`
- examples/vite/src/main.ts: `SpecValidatorError` を明示的に catch して表示
- examples/vite/src/github/spec.ts: `@notainc/typed-api-spec/ss` → `@notainc/typed-api-spec/core`、`SSApiEndpoints` → `ApiEndpointsSchema`

### examples/vite-react-openapi（peer 制約の解消）
- examples/vite-react-openapi/package.json: `vite: ^6.0.5` → `^8.0.16`
  - plugin-react@6.0.2 の peer 制約を満たす

### examples/misc
- examples/misc/express/zod/openapi/index.ts: `import "zod-openapi/extend";` を削除
  - zod-openapi 5.x で `./extend` サブパスが削除された

### root readme
- readme.md: `examples/` の各 workspace へのリンクを追加、辿れるように

## スコープ外

- **examples の CI 組込**（別 PR で対応予定）: `examples/vite` と `examples/vite-react-openapi` を `all.yaml` に build ステップとして追加。
- viteの脆弱性対応（アップグレード）は別PRで対応
