### PR TITLE
CI に Vite examples の build ステップを追加

### DIFF
--- a/.github/workflows/all.yaml
+++ b/.github/workflows/all.yaml
@@ -27,3 +27,5 @@ jobs:
       - run: npm ci
       - run: npm run build -w pkgs/typed-api-spec
       - run: npm test -w examples/misc
+      - run: npm run build -w examples/vite
+      - run: npm run build -w examples/vite-react-openapi

--- a/examples/vite-react-openapi/src/swagger-ui-react.d.ts
+++ b/examples/vite-react-openapi/src/swagger-ui-react.d.ts
@@ -1,0 +1,1 @@
+declare module "swagger-ui-react";


### PR DESCRIPTION
## 概要
`examples/vite` と `examples/vite-react-openapi` の build を `all.yaml` の `examples` job に追加。合わせて `vite-react-openapi` の `tsc` を通すために `swagger-ui-react` の module 宣言 .d.ts を追加。

追加理由はexampleのビルドが壊れていることに気づけなかったため
See: https://github.com/nota/typed-api-spec/pull/250

## スコープ外

- viteの脆弱性対応（アップグレード）は別PRで対応
