### PR TITLE
chore(ci): dependabot の github-actions に cooldown を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 3
     labels:
       - 'dependencies'


### PR DESCRIPTION
## 概要
`dependabot.yml` の github-actions セクションに `cooldown: default-days: 3` を追加。pinact の `min_age: 3` と揃える。

## 背景
PR #272 で pinact が min-age violation で落ちた:
https://github.com/nota/typed-api-spec/actions/runs/31149913105/attempts/1

